### PR TITLE
ET3 '0/0/0' date error test suite update

### DIFF
--- a/features/et3/claiments_details_page.feature
+++ b/features/et3/claiments_details_page.feature
@@ -6,7 +6,7 @@ Background: ET3 claimants details page
   Given I am on the ET3 claimants details page
 
 Scenario: Verify Claimants details copy
-    Then Claimants details page copy texts are displayed in the correct language
+  Then Claimants details page copy texts are displayed in the correct language
 
 Scenario: Successfully submits all the claimants details
   When I successfully submit all the claimants details
@@ -21,3 +21,11 @@ Scenario: Dates given by the claimant optional validation
   But I do not provide the correct employment dates or give a reason
 #  Then I should see the error message saying the further information about dates cant be blank
   Then I should be taken to the earnings and benefits page
+
+Scenario: Invalid date format '0/0/0' provided
+  When I select no to are the dates given by the claimant correct
+  And I enter invalid dates in the incorrect format
+  Then I should still be on the claimant details page and not on the earnings and benefits page
+
+
+

--- a/features/factories/et3_claimant_factory.rb
+++ b/features/factories/et3_claimant_factory.rb
@@ -30,6 +30,32 @@ FactoryBot.define do
     disagree_employment {"lorem ipsum employment"}
   end
 
+  trait :disagree_with_employment_dates_invalid_date do
+    claimants_name { Faker::Name.name }
+    agree_with_early_conciliation_details {:"questions.agree_with_early_conciliation_details.options.no"}
+    disagree_conciliation_reason {"lorem ipsum conciliation"}
+    continued_employment {:"questions.continued_employment.options.no"}
+    agree_with_claimants_description_of_job_or_title {:"questions.agree_with_claimants_description_of_job_or_title.options.no"}
+    disagree_claimants_job_or_title {"lorem ipsum job title"}
+    agree_with_claimants_hours {:"questions.agree_with_claimants_hours..options.no"}
+    queried_hours {32.0}
+    agree_with_earnings_details {:"questions.agree_with_earnings_details.options.no"}
+    queried_pay_before_tax {1000.0}
+    queried_pay_before_tax_period {"Monthly"}
+    queried_take_home_pay {900.0}
+    queried_take_home_pay_period {"Monthly"}
+    agree_with_claimant_notice {:"questions.agree_with_claimant_notice.options.no"}
+    disagree_claimant_notice_reason {"lorem ipsum notice reason"}
+    agree_with_claimant_pension_benefits {:"questions.agree_with_claimant_pension_benefits.options.no"}
+    disagree_claimant_pension_benefits_reason {"lorem ipsum claimant pension"}
+    defend_claim {:"questions.defend_claim.options.yes"}
+    defend_claim_facts {"lorem ipsum defence"}
+    agree_with_employment_dates {:"questions.agree_with_employment_dates.options.no"}
+    employment_start {"0/0/0"}
+    employment_end {"0/0/0"}
+    disagree_employment {"lorem ipsum employment"}
+  end
+
   trait :agree_with_employment_dates do
     claimants_name { Faker::Name.name }
     agree_with_early_conciliation_details {:"questions.agree_with_early_conciliation_details.options.no"}

--- a/features/step_definitions/et3_claiments_details_page_steps.rb
+++ b/features/step_definitions/et3_claiments_details_page_steps.rb
@@ -1,6 +1,5 @@
 Given(/^I am on the ET3 claimants details page$$/) do
   @respondent = FactoryBot.create_list(:et3_respondent, 1, :et3_respondent_answers)
-  @claimant = FactoryBot.create_list(:et3_claimant, 1, :agree_with_employment_dates)
   start_a_new_et3_response
   et3_answer_respondents_details
 end
@@ -14,10 +13,12 @@ Then("Claimants details page copy texts are displayed in the correct language") 
 end
 
 When(/^I successfully submit all the claimants details$/) do
+  @claimant = FactoryBot.create_list(:et3_claimant, 1, :disagree_with_employment_dates)
   et3_answer_claimants_details
 end
 
 When(/^I successfully submit required claimants details only$/) do
+  @claimant = FactoryBot.create_list(:et3_claimant, 1, :agree_with_employment_dates)
   et3_answer_required_claimants_details
 end
 
@@ -31,4 +32,13 @@ end
 
 When(/^I select no to are the dates given by the claimant correct$/) do
   claimants_details_page.agree_with_employment_dates_question.set(:no)
+end
+
+And(/^I enter invalid dates in the incorrect format$/) do
+  @claimant = FactoryBot.create_list(:et3_claimant, 1, :disagree_with_employment_dates_invalid_date)
+  et3_answer_claimants_details
+end
+
+Then(/^I should still be on the claimant details page and not on the earnings and benefits page$/) do
+  expect(claimants_details_page).to have_header
 end


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RST-6254

### Description ###
Updated test suite to add in functionality of verifying error messages when entering an invalid '0/0/0' date in ET3. Might fail on ET3 master branch currently as RST-6254 is not yet merged.

### Checklist
- [ x ] commit messages are meaningful and follow good commit message guidelines
- [ x ] README and other documentation has been updated / added (if needed)
- [ x ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
