### PR TITLE
(RST-7745) Add openssl gem in test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ group :test do
   gem 'capybara-screenshot', '~> 1.0'
   gem 'cucumber', '~> 9.0'
   gem 'aws-sdk-s3', '~> 1.9'
+  # OpenSSL gem to fix issues with cucumber test report uploads over HTTPS
+  gem 'openssl', '~> 3.3'
 
   # Rubyzip used to test zip files
   gem 'rubyzip', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    openssl (3.3.2)
     parallel (1.24.0)
     parallel_tests (4.5.0)
       parallel
@@ -278,6 +279,7 @@ DEPENDENCIES
   i18n (~> 1.8)
   mail
   mechanize (~> 2.7, >= 2.7.6)
+  openssl (~> 3.3)
   parallel_tests
   pdf-forms (~> 1.1, >= 1.1.1)
   pdf-reader (~> 2.11)


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [RST-7745](https://tools.hmcts.net/jira/browse/RST-7745).

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

Fixing issues with reports.cucumber.io uploads on newer versions of macOS using OpenSSL.